### PR TITLE
API to create the pre-signed uri

### DIFF
--- a/s3-signer.cabal
+++ b/s3-signer.cabal
@@ -44,6 +44,7 @@ library
                      , http-types
                      , cryptohash
                      , time
+                     , uri-bytestring
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:        -Wall
@@ -74,6 +75,7 @@ test-suite test-simple
                      , http-types
                      , cryptohash
                      , time
+                     , uri-bytestring
 
 source-repository head
   type:     git

--- a/src/Network/S3/Types.hs
+++ b/src/Network/S3/Types.hs
@@ -9,6 +9,7 @@ module Network.S3.Types
     , getS3Header
     , s3Header
     , s3HeaderBuilder
+    , emptyHash
     ) where
 
 import           Data.ByteString.UTF8     (ByteString)
@@ -42,10 +43,16 @@ data S3Request = S3Request {
     , regionName  :: ByteString       -- ^ Name of Amazon S3 Region
     , queryString :: Query            -- ^ Optional query string items
     , requestTime :: UTCTime          -- ^ Requests are valid within a 15 minute window of this timestamp
-    , payloadHash :: Maybe ByteString -- ^ SHA256 hash string of the payload
+    , payloadHash :: Maybe ByteString -- ^ SHA256 hash string of the payload; Nothing if unsigned
     , s3headers   :: [S3Header]       -- ^ Headers
+    , expires     :: Int              -- ^ Expiration in seconds
+    , s3Key         :: ByteString
+    , s3Secret      :: ByteString
     } deriving (Generic, Show)
 
+-- | Hash of empty payload
+emptyHash :: ByteString
+emptyHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 data S3SignedRequest = S3SignedRequest {
       sigHeaders    :: [S3Header] -- ^ The headers included in the signed request

--- a/src/Network/S3/URL.hs
+++ b/src/Network/S3/URL.hs
@@ -2,11 +2,8 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module Network.S3.URL
-    ( canonicalRequest
-    ) where
+    ( canonicalRequest ) where
 
-import           Data.Time.Format         (formatTime, defaultTimeLocale)
-import           Data.ByteString.Char8    (pack)
 import           Blaze.ByteString.Builder (Builder, fromByteString)
 
 import qualified Network.HTTP.Types.URI as HTTP
@@ -20,22 +17,13 @@ import           Network.S3.Types
 sortS3Headers :: [S3Header] -> [S3Header]
 sortS3Headers = sortBy (compare `on` (fst . getS3Header))
 
-
--- | Build a canonical request to be signed
---   AWS docs: https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html#canonical-request
 canonicalRequest :: S3Request -> Builder
 canonicalRequest S3Request{..} =
   let
     -- We MUST sort the parameters in the query string alphabetically by key name
     qs         = sortBy (compare `on` fst) queryString
-    emptyHash  = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-    bodyHash   = fromMaybe emptyHash payloadHash
-    hashHeader = s3Header "x-amz-content-sha256" bodyHash
-    hostHeader = s3Header "host" (bucketName <> ".s3.amazonaws.com")
-    seconds    = pack (formatTime defaultTimeLocale "T%H%M%SZ" requestTime)
-    date       = pack (formatTime defaultTimeLocale "%Y%m%d" requestTime)
-    timeHeader = s3Header "x-amz-date" (date <> seconds)
-    headers    = sortS3Headers (timeHeader : hostHeader : hashHeader : s3headers)
+    bodyHash   = fromMaybe "UNSIGNED-PAYLOAD" payloadHash
+    headers    = sortS3Headers s3headers
     headerKeys = map (fst . getS3Header) headers
 
     httpMethod       = renderS3Method s3method
@@ -54,7 +42,6 @@ canonicalRequest S3Request{..} =
       hashedPayload
   in
     uriBuilder
-
 
 renderS3Method :: S3Method -> Builder
 renderS3Method method =


### PR DESCRIPTION
I'm unsure what aim the new API had, but I couldn't make it sign the normal uri to be used with S3. And the discussion in #10 seems to suggest that I'm not alone. This pull request makes the function to generate just the signed uri.
I really don't know what is the use case for the existing code - I think it should be relatively easy to add the functionality from 0.5.0.0, but I'd need some info about how was it used. Using just the URI seems to me much simpler.